### PR TITLE
Implement error object links.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -23,6 +23,14 @@ type ErrorsPayload struct {
 	Errors []*ErrorObject `json:"errors"`
 }
 
+// ErrorObjectLinks is an implementation of the JSON API error links payload.
+//
+// For more information on the JSON API spec's error links objects, see: http://jsonapi.org/format/#error-objects
+type ErrorObjectLinks struct {
+	// About is a link that leads to further details about this particular occurrence of the problem.
+	About string `json:"about"`
+}
+
 // ErrorObject is an `Error` implementation as well as an implementation of the JSON API error object.
 //
 // The main idea behind this struct is that you can use it directly in your code as an error type
@@ -44,6 +52,9 @@ type ErrorObject struct {
 
 	// Code is an application-specific error code, expressed as a string value.
 	Code string `json:"code,omitempty"`
+
+	// Links is an implementation of the JSON API error links payload.
+	Links *ErrorObjectLinks `json:"links,omitempty"`
 
 	// Meta is an object containing non-standard meta-information about the error.
 	Meta *map[string]interface{} `json:"meta,omitempty"`


### PR DESCRIPTION
@jsignanini I've forked `google/jsonapi` in the interest of bringing in a couple PRs that are currently languishing in the main repo. This PR merges your work to add support for the "About" links into my fork.